### PR TITLE
fix: await Clerk async APIs

### DIFF
--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -3,7 +3,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { stripe, handleSubscriptionChange } from "@/lib/payments/stripe";
 
 export const GET = async (request: NextRequest) => {
-  const { userId } = auth();
+  const { userId } = await auth();
 
   if (!userId) {
     return NextResponse.redirect(new URL("/pricing", request.url));

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -24,7 +24,8 @@ export const updateUserSubscription = async (
 };
 
 const createUser = async (clerkId: string): Promise<User> => {
-  const clerkUser = await clerkClient.users.getUser(clerkId);
+  const clerk = await clerkClient();
+  const clerkUser = await clerk.users.getUser(clerkId);
   const newUser: NewUser = {
     clerkId,
     role: "member",
@@ -53,7 +54,7 @@ export const getUserByClerkId = async (clerkId: string): Promise<User> => {
 };
 
 export const getPullRequests = async (): Promise<PullRequest[]> => {
-  const { userId } = auth();
+  const { userId } = await auth();
   if (!userId) {
     throw new Error("User not authenticated");
   }

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -13,10 +13,10 @@ const matchTestPatterns = (testPatterns: string[], filePath: string) =>
   );
 
 export const getOctokit = async () => {
-  const { userId } = auth();
+  const { userId } = await auth();
   if (!userId) throw new Error("Clerk: User not authenticated");
 
-  const clerk = clerkClient();
+  const clerk = await clerkClient();
   const [{ token: githubToken }] = await clerk.users
     .getUserOauthAccessToken(userId, "oauth_github")
     .then(({ data }) => data);

--- a/lib/payments/stripe.ts
+++ b/lib/payments/stripe.ts
@@ -115,7 +115,7 @@ export const handleSubscriptionChange = async (
   const subscriptionId = subscription.id;
   const status = subscription.status;
 
-  const { userId } = auth();
+  const { userId } = await auth();
   if (!userId) {
     console.error("User not authenticated");
     return;


### PR DESCRIPTION
## Summary
- await Clerk auth and client calls to comply with Next.js async headers
- ensure Stripe checkout and subscription handlers use authenticated user

## Testing
- `pnpm lint`
- `pnpm nextjs:typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68baf4e1d6348320a42ac39f90a8b193