### PR TITLE
refactor: centralize system prompt builder

### DIFF
--- a/packages/shortest/src/ai/prompts/index.ts
+++ b/packages/shortest/src/ai/prompts/index.ts
@@ -1,6 +1,7 @@
 import os from "os";
+import { buildSystemPrompt } from "./utils/build-system-prompt";
 
-export const SYSTEM_PROMPT = `You are a test automation expert working with a Chrome browser.
+export const SYSTEM_PROMPT_TEMPLATE = `You are a test automation expert working with a Chrome browser.
 You will be given test instructions, and your task is to execute specified browser actions to validate the provided test cases.
 You are already in the Chrome browser and on the relevant application page, so there is no need to open or initialize the browser yourself.
 
@@ -57,13 +58,22 @@ IMPORTANT GLOBAL RULES:
    - When generating bash commands, ensure they are appropriate for the operating system you are currently using: ${os.platform()}.
    - If you are asked to generate bash command for API requests, you should make sure you replace placeholders (<>) in the request details with the actual values from memory or context.
 
-Your task is to:
-1. Execute browser actions to validate test cases
-2. Use provided browser tools to interact with the page
-3. Return test execution results in strict JSON format: { status: "passed" | "failed", reason: string }.
-   For failures, provide a maximum 1-sentence reason.
-   IMPORTANT:
-   - DO NOT include anything else in your response, only the result and reason.
-   - DO NOT include any other JSON-like object in your response except the required structure.
-   - If there's need to do that, remove braces {} to ensure it's not interpreted as JSON.
-4. For click actions, provide x,y coordinates of the element to click.`;
+{{TASK_BLOCK}}
+{{OUTPUT_BLOCK}}`;
+
+export const SYSTEM_PROMPT = buildSystemPrompt(SYSTEM_PROMPT_TEMPLATE, {
+  TASK_BLOCK: [
+    "Your task is to:",
+    "1. Execute browser actions to validate test cases",
+    "2. Use provided browser tools to interact with the page",
+  ].join("\n"),
+  OUTPUT_BLOCK: [
+    'Return test execution results in strict JSON format: { status: "passed" | "failed", reason: string }.',
+    "For failures, provide a maximum 1-sentence reason.",
+    "IMPORTANT:",
+    "- DO NOT include anything else in your response, only the result and reason.",
+    "- DO NOT include any other JSON-like object in your response except the required structure.",
+    "- If there's need to do that, remove braces {} to ensure it's not interpreted as JSON.",
+    "For click actions, provide x,y coordinates of the element to click.",
+  ].join("\n"),
+});

--- a/packages/shortest/src/ai/prompts/utils/build-system-prompt.ts
+++ b/packages/shortest/src/ai/prompts/utils/build-system-prompt.ts
@@ -1,0 +1,8 @@
+export const buildSystemPrompt = (
+  template: string,
+  blocks: Record<string, string>,
+): string =>
+  Object.entries(blocks).reduce(
+    (prompt, [key, value]) => prompt.replace(`{{${key}}}`, value),
+    template,
+  );


### PR DESCRIPTION
## Summary
- add `buildSystemPrompt` utility for filling template placeholders
- export `SYSTEM_PROMPT` by calling `buildSystemPrompt` with task/output blocks
- restore `TestBuilder` and update `AIClient` to import prompt from prompts module

## Testing
- `pnpm lint`
- `pnpm -F @antiwork/shortest test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68baf70661f88320aededcbebfea4bd8